### PR TITLE
Fix fileext function pattern matching

### DIFF
--- a/R/loading.R
+++ b/R/loading.R
@@ -398,7 +398,7 @@ save.video <- function(im,fname,...)
 #borrowed from pkgmaker::file_extension
 fileext <- function(f)
 {
-    sub(".*\\.([^.]{3})$", "\\1", f) %>% tolower
+    sub(".*\\.([^.]{3,4})$", "\\1", f) %>% tolower
 }
 
                     


### PR DESCRIPTION
Given the {3} quantifier in the expression, the current fileext function matches only three letters following the period, so it can extract the jpg file extension, but it can't extract the extension when jpeg is used:

> fileext <- function() { sub(".*\\.([^.]{3})$", "\\1", f) %>% tolower }
> fileext("myimage.jpeg")
[1] "myimage.jpeg"
> fileext("myimage.jpg")
[1] "jpg"

Therefore, when load.image for example checks to see if the output of fileext is png, jpg, jpeg, or bmp, it will raise an error for jpeg extensions, even though they are supported.

I modified it to match three or four characters after the period, so it will work on jpeg extensions as well. I tested the solution, and it matched only those expressions with 3-4 characters:

> fileext <- function(f) { sub(".*\\.([^.]{3,4})$", "\\1", f) %>% tolower }
> fileext("myimage.jpeg")
[1] "jpeg"
> fileext("myimage.jpg")
[1] "jpg"
> # fails when there are more than four characters or less than three
> fileext("myimage.jpgafdsa")
[1] "myimage.jpgafdsa"
> fileext("myimage.jp")
[1] "myimage.jp"
> fileext("myimage.j")
[1] "myimage.j"