### PR TITLE
Small typo on required header for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Building R packages on Windows is a bit of a pain so you're probably better off 
 
 To build under Linux make sure you have the headers for libX11 and libfftw3 (optionally, libtiff as well). On my Ubuntu system this seems to be enough:
 
-	sudo apt-get install libfftw3-dev libX11-dev libtiff-dev
+	sudo apt-get install libfftw3-dev libx11-dev libtiff-dev
 
 
 ### External dependencies


### PR DESCRIPTION
The `libX11-dev` header is actually named `libx11-dev`. Just changing the `X` to lowercase on README so copying and pasting the command should work correctly, making installation simpler.