### PR TITLE
added LICENSE in .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 .gitignore
 m4
 joss
+LICENSE


### PR DESCRIPTION
fixed the NOTE shown below.
> checking top-level files ... NOTE
  File LICENSE is not mentioned in the DESCRIPTION file.

CRAN allows us to keep LICENSE file in package source when LICENSE file is mentioned in DESCRIPTION file and LICENSE file is not full text of license.

The LICENSE file is a full text of LGPL-3.

Therefore, we must not keep the LICENSE file in the package source of imager.

However, we should keep the LICENSE file in this repository because the LICENSE file makes clear the license of imager.

That's why I just added LICENSE in .Rbuildignore file.